### PR TITLE
Add ability to specify MaxFileAttempts on cmd line

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 # bettersigntool
+
 A wrapper around signtool with added features
 
 * Batch mode (supply a .txt of filenames)
@@ -7,7 +8,8 @@ A wrapper around signtool with added features
 
 Currently only supports the **sign** operation with a PFX and password
 
-##Basic usage
+## Basic usage
+
 Almost all switches are named the same as the default signtool (`/du` is `-du`, for example). The only exception is the input filename, which must be prefixed with `-I` (capital i)
 
 	bettersigntool -d "Organisation Name" -du "http://mycompany.com" -f "C:\my.pfx" -p "password" -I myfile.dll
@@ -15,31 +17,32 @@ Almost all switches are named the same as the default signtool (`/du` is `-du`, 
 By default, the timeserver is Verisign, but you can override this by specifying the `-t` argument, as per the default signtool, i.e.:
 
 	-t "http://timestamp.myspecialtimeserver.com"
-    
 
-##Batch mode
-bettersigntool can take a .txt file and sign all of the filenames listed inside of it. The paths should be relative to the location of the .txt file itself 
+## Batch mode
+
+bettersigntool can take a .txt file and sign all of the filenames listed inside of it. The paths should be relative to the location of the .txt file itself.
 
 The .txt extension is automatically detected on the input file and the tool behaves accordingly.
 
 e.g.
 
-**myfile.txt**
+### myfile.txt
 
 	bin/file.dll
 	bin/file2.dll
 
-
-**Calling arguments**
+### Calling arguments
 
 	bettersigntool -d "Organisation Name" -du "http://mycompany.com" -f "C:\my.pfx" -p "password" -I myfile.txt
 
 Both `file.dll` and `file2.dll` will be signed as a result of the above
 
 ## Failure mode
-As mentioned above, bettersigntool supports retry with exponential back-off. Currently the settings for this are **not** exposed as command line options (but will be).
 
-The behaviour is currently fixed as:
+As mentioned above, bettersigntool supports retry with exponential back-off. By default the tool will attempt 2 retries (three attempts total) per file but you can set this number via the optional `-ma` parameter.
+
+The default behaviour is currently:
+
 * Signing will be attempted a *total* of 3 times (i.e. 1 initial attempt, 2 retries)
 * Initial retry delay is 3 seconds (3000ms)
 * Back-off occurs with an exponent of 1.5 (wait 3 seconds, 5.196 seconds, finally 11.844 seconds)

--- a/bettersigntool/bettersigntool/SignCommand.cs
+++ b/bettersigntool/bettersigntool/SignCommand.cs
@@ -344,8 +344,11 @@ namespace bettersigntool
 
             do
             {
-                Console.WriteLine($"Performing attempt #{attempt} of {MaximumFileAttempts} after {retryWait.TotalSeconds}s...");
-                Thread.Sleep((int)retryWait.TotalMilliseconds);
+                if (attempt > 1) 
+                {
+                    Console.WriteLine($"Performing attempt #{attempt} of {MaximumFileAttempts} after {retryWait.TotalSeconds}s...");
+                    Thread.Sleep((int)retryWait.TotalMilliseconds);
+                }
 
                 if (RunSigntool(filename))
                 {

--- a/bettersigntool/bettersigntool/SignCommand.cs
+++ b/bettersigntool/bettersigntool/SignCommand.cs
@@ -165,11 +165,7 @@ namespace bettersigntool
         /// <summary>
         /// Maximum number of attempts per file
         /// </summary>
-        public int MaximumFileAttempts
-        {
-            get;
-            set;
-        }
+        public int MaximumFileAttempts { get; set; } = 3;
 
         /// <summary>
         /// After the initial failure of signing, we wait this long before trying again
@@ -244,6 +240,9 @@ namespace bettersigntool
                 "Displays verbose output for successful execution, failed execution, and warning messages..",
                 v => Verbose = String.IsNullOrEmpty(v) ? false : true);
 
+            HasOption("ma|MaxFileAttempts=",
+                "The maximum number of attempts to sign each file, should a timeout occur. If ommited, 3 is used.",
+                ma => MaximumFileAttempts = int.Parse(ma));
 
             // Fallback to Verisign
             //
@@ -260,7 +259,6 @@ namespace bettersigntool
                     @"Windows Kits\8.1\bin\x64\signtool.exe");
             }
 
-            MaximumFileAttempts = 3;
             InitialRetryWait = TimeSpan.FromSeconds(3);
             BackoffExponent = 1.5;
         }
@@ -346,11 +344,8 @@ namespace bettersigntool
 
             do
             {
-                if (attempt > 1)
-                {
-                    Console.WriteLine($"Performing attempt #{attempt} of {MaximumFileAttempts} after {retryWait.TotalSeconds}s...");
-                    Thread.Sleep((int)retryWait.TotalMilliseconds);
-                }
+                Console.WriteLine($"Performing attempt #{attempt} of {MaximumFileAttempts} after {retryWait.TotalSeconds}s...");
+                Thread.Sleep((int)retryWait.TotalMilliseconds);
 
                 if (RunSigntool(filename))
                 {


### PR DESCRIPTION
This PR exposes the `MaxFileAttempts` property via the command line.  The default behaviour is still 3 max attempts (set via a default on the auto-property), but now the `ma|MaxAttempts` parameter can be specified.

I also updated the readme to reflect this (and fixed some minor markdown errors).