### PR TITLE
Change to jittered back-off with exponent of 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,5 +44,7 @@ As mentioned above, bettersigntool supports retry with exponential back-off. By 
 The default behaviour is currently:
 
 * Signing will be attempted a *total* of 3 times (i.e. 1 initial attempt, 2 retries)
-* Initial retry delay is 3 seconds (3000ms)
-* Back-off occurs with an exponent of 1.5 (wait 3 seconds, 5.196 seconds, finally 11.844 seconds)
+* Initial base is 6 seconds (6000ms), with an exponent of 2 for each subsequent attempt
+* Each back-off delay is jittered to between 50-100% of base
+* Initial delay is between 3-6 seconds (6000ms)
+* Second delay is between 6 and 12 seconds


### PR DESCRIPTION
This should produce a better curve when max attempts is greater than 3, as previous implementation would start waiting far too long between attempts (4 minutes then jumped to almost an hour!)

Jitter should reduce failure when builds are triggered at the same time.

It's also worth noting that due to a bug in the original implementation the first retry interval was never used (exponent was immediately applied).  W.r.t to backwards compatibility, due to the new implementation callers will see approx the same initial waits on the first and second retry on average because of said bug! 😄 